### PR TITLE
Update Node version to v18

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -2,22 +2,22 @@ name: Okteto Deployment
 
 on:
   push:
-    branches: [ main ]
-    
+    branches: [main]
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - uses: actions/checkout@v2
-    
-    - name: Okteto login
-      uses: okteto/login@latest
-      with:
-        token: ${{ secrets.OKTETO_TOKEN }}
-        
-    - name: Okteto deploy
-      uses: resinas/okteto-push@v1.0.2
-      with:
-        namespace: fastmusik-marmolpen3
-        build: true
+      - uses: actions/checkout@v3
+
+      - name: Okteto login
+        uses: okteto/login@latest
+        with:
+          token: ${{ secrets.OKTETO_TOKEN }}
+
+      - name: Okteto deploy
+        uses: resinas/okteto-push@v1.0.2
+        with:
+          namespace: fastmusik-marmolpen3
+          build: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
         node-version: [14.x, 16.x, 18.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14 as dev
+FROM node:18 as dev
 
 WORKDIR /src
 


### PR DESCRIPTION
He actualizado también CI a la versión v3 de checkout, que también lo renomendabla GitHub, por estar v2 asociado a una versión antigua (descontinuada) de Node, la v12.

He desplegado en workspace de Okteto de prueba y funciona. A ver si así deja de dar el problema de la imagen.